### PR TITLE
Explicity depend on gulp-ruby-sass

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -5,11 +5,11 @@ var colors = require('colors');
 var watch = require('gulp-watch');
 var concat = require('gulp-concat');
 var sass = require('gulp-ruby-sass');
+var sourcemaps = require('gulp-sourcemaps');
 var minifyCss = require('gulp-minify-css');
 var rename = require('gulp-rename');
 var fileinclude = require('gulp-file-include');
 var cssStats = require('gulp-cssstats');
-var postcss = require('gulp-postcss');
 var gulpIgnore = require('gulp-ignore');
 var scsslint = require('gulp-scss-lint');
 
@@ -29,16 +29,15 @@ gulp.task('scss-lint', function () {
 });
 
 
-gulp.task('sass', ['scss-lint'], function(done) {
-  gulp.src('./scss/skeletor.scss')
-    .pipe(sass({
-      sourcemap: false,
-      sourcemapPath: '../scss'
-    }))
-    .on('error', function (err) {
-      console.log(err.message);
+gulp.task('sass', ['scss-lint'], function() {
+  return sass('./scss/skeletor.scss', {
+      sourcemap: true,
     })
-    .pipe(gulp.dest('./css/'))
+    .pipe(sourcemaps.write('./', {
+      includeContent: false,
+      sourceRoot: '/scss'
+    }))
+    .pipe(gulp.dest('./css'))
     .pipe(gulpIgnore.exclude(function(file) {
       if (file.path.indexOf('.map') !== -1) {
         return true;
@@ -50,9 +49,11 @@ gulp.task('sass', ['scss-lint'], function(done) {
     .pipe(rename({
       extname: '.min.css'
     }))
-    .pipe(gulp.dest('./css/'))
-    .pipe(connect.reload())
-    .on('end', done);
+    .pipe(gulp.dest('./css'))
+    .on('error', function (err) {
+      console.error(err.message);
+    })
+    .pipe(connect.reload());
 });
 
 

--- a/package.json
+++ b/package.json
@@ -18,19 +18,21 @@
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "devDependencies": {
-    "gulp": "^3.8.10",
-    "connect-livereload": "0.5.2",
     "colors": "^1.0.3",
-    "gulp-connect": "2.2.0",
-    "gulp-watch": "3.0.0",
-    "gulp-sass": "1.1.0",
+    "connect-livereload": "0.5.2",
+    "gulp": "^3.8.10",
     "gulp-concat": "2.4.2",
-    "gulp-minify-css": "^0.3.11",
-    "gulp-rename": "1.2.0",
-    "node-bourbon": "1.2.3",
+    "gulp-connect": "2.2.0",
+    "gulp-cssstats": "^1.0.0",
     "gulp-file-include": "^0.7.1",
     "gulp-ignore": "^1.2.1",
+    "gulp-minify-css": "^0.3.11",
+    "gulp-rename": "1.2.0",
+    "gulp-ruby-sass": "^1.0.0-alpha.3",
+    "gulp-sass": "1.1.0",
     "gulp-scss-lint": "^0.1.4",
-    "gulp-cssstats": "^1.0.0"
+    "gulp-sourcemaps": "^1.3.0",
+    "gulp-watch": "3.0.0",
+    "node-bourbon": "1.2.3"
   }
 }


### PR DESCRIPTION
The gulp syntax has been updated to match the new alpha versions of
gulp-ruby-sass. Additionally, sourcemap support was updated and an old
reference to postcss removed.

This closes #4 and closes #5.