### PR TITLE
Make node-bourbon a runtime dep

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,9 @@
     "gulp-sass": "1.1.0",
     "gulp-scss-lint": "^0.1.4",
     "gulp-sourcemaps": "^1.3.0",
-    "gulp-watch": "3.0.0",
-    "node-bourbon": "1.2.3"
+    "gulp-watch": "3.0.0"
+  },
+  "dependencies": {
+    "node-bourbon": "^1.2.3"
   }
 }


### PR DESCRIPTION
The dep was moved out of the dev dependencies as it's a runtime
dependency. This move should allow Skeletor to be used with a simple
`npm install`.