### PR TITLE
Make link to css stats relative

### DIFF
--- a/docs/sections/_cssstats.html
+++ b/docs/sections/_cssstats.html
@@ -3,7 +3,7 @@
   <h6 class="docs-header">CSS Stats</h6>
   <p><a href="https://www.npmjs.com/package/cssstats">cssstats</a> parses the compiled CSS stylesheet and returns an object with statistics. These are high-level stats which help you analyse the performance and maintainability of your code. It helps you avoid bloat, catch redundant rules, and keep a low average specificity of selectors.</p>
 
-  <p>The visualization of these stats are available at <a href="http://localhost:3000/css/stats">localhost:3000/css/stats</a>. The visualization is based on CSS Stats by <a href="http://mrmrs.cc" class="bold dark-gray">Mrmrs</a> &amp; <a href="http://jxnblk.com" class="bold dark-gray">Jxnblk</a>.</p>
+  <p>The visualization of these stats are available at <a href="/css/stats">/css/stats</a>. The visualization is based on CSS Stats by <a href="http://mrmrs.cc" class="bold dark-gray">Mrmrs</a> &amp; <a href="http://jxnblk.com" class="bold dark-gray">Jxnblk</a>.</p>
 
   <ul>
     <li><a href="http://webdesign.tutsplus.com/tutorials/understanding-css-stats-how-to-make-the-most-of-the-numbers--cms-22756">Understanding CSS Stats: How to Make the Most of the Numbers</a></li>


### PR DESCRIPTION
This is a fix for the broken link on gh pages. I know these are moving but I imagine they'll still be hosted.